### PR TITLE
Use advanced Spotify auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,26 @@
 # My Twitch Chatbot
 
-My Twitch chatbot with some simple commands, including friendcode display and
-currently playing Spotify song.
+My locally-running Twitch chatbot for some simple commands, including ID display
+and currently-playing Spotify song.
 
-Probably should be run on a machine since there are tokens involved.
+Good for not having to depend on your own machine's Spotify desktop application,
+but instead Spotify's API data that they have on you.
+
+Note that Spotify's API requires OAuth 2.0 to get any user data, which makes for
+a somewhat complicated authentication process (it in fact requires the use of an
+actual Spotify app). The directions here allow you to quickly stand up your own
+app (it does not have to be published), so that you're authenticating to what
+you've made yourself, rather than someone else's live app.
+
+## Register as a Spotify Developer
+
+1. Register as a [Spotify Developer](https://developer.spotify.com/dashboard/login).
+2. Create a project by clicking the "Create a Client ID" and filling out all
+   the appropriate fields.
+3. Go to "Edit Settings" and add `http://localhost:3000/callback` to the
+   whitelist of Redirect URIs.
+4. Make note of the app's associated Client ID and Client Secret. These get
+   used when configuring this bot later (see the Configure section).
 
 ## Install
 
@@ -30,9 +47,9 @@ following format:
 
 - `BOT_USER` can be the same handle you use for your channel.
 - `GAME_ID` example: Nintendo Switch Friend Code
-- `TWITCH_TOKEN` can be retrieved from [here](https://twitchapps.com/tmi/) (click the broken image button)
-- Register as a [Spotify Developer](https://developer.spotify.com/) to obtain a
-  `SPOTIFY_CLIENT_ID` and a `SPOTIFY_CLIENT_SECRET` for a test app.
+- `TWITCH_TOKEN` can be retrieved from [here](https://twitchapps.com/tmi/)
+  (click the broken image button). This appears to be a long-lived token, so
+  unlike the Spotify integration, no complex authentication process is needed.
 
 ## Run
 

--- a/README.md
+++ b/README.md
@@ -20,16 +20,19 @@ following format:
     module.exports = {
       BOT_USER: '[your bot's twitch handle]',
       CHANNEL: '[your channel]',
+      GAME_ID: '[your gaming id of choice]'
       TWITCH_TOKEN: '[your twitch oauth token]',
-      SPOTIFY_TOKEN: '[your spotify account's oauth token]',
-      GAME_ID: '[your gaming id of choice, e.g. nintendo switch friend code]'
+      SPOTIFY_CLIENT_ID: '[your spotify app's client_id]',
+      SPOTIFY_CLIENT_SECRET: '[your spotify app's client_secret]',
     }
 
 ### Notes
 
 - `BOT_USER` can be the same handle you use for your channel.
+- `GAME_ID` example: Nintendo Switch Friend Code
 - `TWITCH_TOKEN` can be retrieved from [here](https://twitchapps.com/tmi/) (click the broken image button)
-- `SPOTIFY_TOKEN` can be retrieved from [here](https://developer.spotify.com/console/get-users-currently-playing-track/)
+- Register as a [Spotify Developer](https://developer.spotify.com/) to obtain a
+  `SPOTIFY_CLIENT_ID` and a `SPOTIFY_CLIENT_SECRET` for a test app.
 
 ## Run
 

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ app.get('/callback', (req, res) => {
             .then(res => res.json())
             .then(updatedTokens => {
               accessToken = updatedTokens.access_token
-              refreshToken = updatedTokens.refresh_token
+              refreshToken = updatedTokens.refresh_token || refreshToken
               fetch('https://api.spotify.com/v1/me/player/currently-playing', {
                 headers: {
                   Authorization: `Bearer ${accessToken}`

--- a/index.js
+++ b/index.js
@@ -42,8 +42,7 @@ app.get('/callback', async (req, res) => {
 
   const handleMessaging = async (currentlyPlayingData, options) => {
     // handle messaging based off of the currentlyPlayingData provided by
-    // spotify. calls self recursively if access token expires (as per retry
-    // threshold specified in options object).
+    // spotify. calls self in the case that access token expires.
 
     if (!options.retries) {
       // if too many refresh attempts or attempts not specified, just tell the
@@ -52,7 +51,10 @@ app.get('/callback', async (req, res) => {
       return client.action(CHANNEL, MSG_BROKEN)
 
     } else if (currentlyPlayingData && currentlyPlayingData.error && currentlyPlayingData.error.message && currentlyPlayingData.error.message.includes('xpire')) {
-      // if expired error, retry
+      // if expired error, retry using refresh token. recursively call,
+      // terminated either by successful access token usage (leading to correct
+      // messaging outside of this condition) or by retry threshold (specified
+      // in options object).
       console.log(`==> Expiration error: ${currentlyPlayingData.error.message}. Retrying.`)
       const spotifyTokenDataUpdated = await requestSpotify.refresh(refreshToken)
       accessToken = spotifyTokenDataUpdated.access_token // update access token

--- a/index.js
+++ b/index.js
@@ -78,11 +78,12 @@ app.get('/callback', async (req, res) => {
 
     } else if (currentlyPlayingData) {
       // if not playing anything, tell user you're not playing anything
-      console.log('==> No song currently playing.')
+      console.log(`==> No song currently playing.${currentlyPlayingData.noSession ? ' (No current session.)' : ''}`)
       return client.action(CHANNEL, MSG_NOT_PLAYING)
 
     } else {
-      // if data wasn't ever even put into function, tell user it's broken
+      // fallback, e.g. if data wasn't ever even put into function, tell user
+      // it's broken
       console.log('==> currentlyPlayingData not provided.')
       return client.action(CHANNEL, MSG_BROKEN)
     }

--- a/index.js
+++ b/index.js
@@ -9,8 +9,6 @@ const { BOT_USER, CHANNEL, GAME_ID, TWITCH_TOKEN, SPOTIFY_CLIENT_ID } = require(
 const csrfGenerator = csrf()
 const CSRF_TOKEN = csrfGenerator.secretSync()
 
-console.log(CSRF_TOKEN)
-
 const app = express()
 const port = 3000
 
@@ -113,5 +111,5 @@ const query = {
   scope: 'user-read-currently-playing',
 }
 const url = `https://accounts.spotify.com/authorize?${qs.stringify(query)}`
-console.log('==> url', url)
+console.log('==> opening url', url)
 open(url)

--- a/index.js
+++ b/index.js
@@ -6,55 +6,56 @@ const open = require('open')
 const requestSpotify = require('./request-spotify')
 const { BOT_USER, CHANNEL, GAME_ID, TWITCH_TOKEN, SPOTIFY_CLIENT_ID } = require('./vars')
 
-const csrfGenerator = csrf()
-const CSRF_TOKEN = csrfGenerator.secretSync()
+const csrfGenerator = new csrf()
+const CSRF_SECRET = csrfGenerator.secretSync()
+const CSRF_TOKEN = csrfGenerator.create(CSRF_SECRET)
+console.log(CSRF_SECRET)
+console.log(CSRF_TOKEN)
+const MSG_BROKEN = 'chatbot/spotify integration is broken lmao'
+const MSG_NOT_PLAYING = 'i\'m not playing anything on spotify rn'
+const COUNT_RETRIES = 3
+const TWITCH_OPTIONS = {
+  options: { debug: true },
+  connection: { cluster: 'aws', reconnect: true },
+  identity: { username: BOT_USER, password: TWITCH_TOKEN },
+  channels: [ CHANNEL ]
+}
 
 const app = express()
 const port = 3000
 
 app.get('/callback', async (req, res) => {
-  if (req.query.state !== CSRF_TOKEN) {
-    return res.send('Authentication failed')
+  if (!csrfGenerator.verify(CSRF_SECRET, req.query.state)) {
+    // spotify recommends the use of the state parameter for CSRF protection.
+    // as a separate note, spotify additionally has extra redirection
+    // protection through the use of a configurable whitelist from your app's
+    // dashboard.
+    return res.send('Authentication failed.')
   }
 
-  res.send('Authentication successful')
+  res.send('Authentication successful. You can now close this page.')
 
   const spotifyTokenData = await requestSpotify.auth(req.query.code)
   let accessToken = spotifyTokenData.access_token
   let refreshToken = spotifyTokenData.refresh_token
 
-  const twitchOptions = {
-    options: {
-      debug: true
-    },
-    connection: {
-      cluster: 'aws',
-      reconnect: true
-    },
-    identity: {
-      username: BOT_USER,
-      password: TWITCH_TOKEN
-    },
-    channels: [
-      CHANNEL
-    ]
-  }
-  const client = new twitch.client(twitchOptions)
-  client.connect()
+  const client = new twitch.client(TWITCH_OPTIONS)
+  client.connect() // only connect to twitch if spotify auth was successful
 
   const handleMessaging = async (currentlyPlayingData, options) => {
     // handle messaging based off of the currentlyPlayingData provided by
-    // spotify. could potentially call self recursively if access token expires.
+    // spotify. calls self recursively if access token expires (as per retry
+    // threshold specified in options object).
 
     if (!options.retries) {
-      // gone through too many refresh attempts, just tell the user it's broken
-      console.log('==> too many refresh attempts')
-      const msg = 'chatbot/spotify integration is broken lmao'
-      return client.action(CHANNEL, msg)
+      // if too many refresh attempts or attempts not specified, just tell the
+      // user it's broken
+      console.log('==> Too many refresh attempts.')
+      return client.action(CHANNEL, MSG_BROKEN)
 
     } else if (currentlyPlayingData && currentlyPlayingData.error && currentlyPlayingData.error.message && currentlyPlayingData.error.message.includes('xpire')) {
       // if expired error, retry
-      console.log('==> expiration error:', currentlyPlayingData.error.message, '- retrying')
+      console.log(`==> Expiration error: ${currentlyPlayingData.error.message}. Retrying.`)
       const spotifyTokenDataUpdated = await requestSpotify.refresh(refreshToken)
       accessToken = spotifyTokenDataUpdated.access_token // update access token
       refreshToken = spotifyTokenDataUpdated.refresh_token || refreshToken // update refresh token *if available*
@@ -63,13 +64,12 @@ app.get('/callback', async (req, res) => {
 
     } else if (currentlyPlayingData && currentlyPlayingData.error) {
       // if other error, just tell the user it's broken
-      console.log('==> miscellaneous error:', currentlyPlayingData.error)
-      const msg = 'chatbot/spotify integration is broken lmao'
-      return client.action(CHANNEL, msg)
+      console.log(`==> Miscellaneous error: ${currentlyPlayingData.error}`)
+      return client.action(CHANNEL, MSG_BROKEN)
 
     } else if (currentlyPlayingData && currentlyPlayingData.is_playing && currentlyPlayingData.item) {
       // if you are playing something, display
-      console.log('==> playing something')
+      console.log('==> Song currently playing.')
       const artists = (currentlyPlayingData.item.artists && currentlyPlayingData.item.artists.map(item => item.name).join(', ')) || 'n/a'
       const title = currentlyPlayingData.item.name || 'n/a'
       const album = (currentlyPlayingData.item.album && currentlyPlayingData.item.album.name) || 'n/a'
@@ -77,16 +77,14 @@ app.get('/callback', async (req, res) => {
       return client.action(CHANNEL, msg)
 
     } else if (currentlyPlayingData) {
-      // if not playing anything, tell user you're not
-      console.log('==> spotify not playing anything')
-      const msg = 'i\'m not playing anything on spotify rn'
-      return client.action(CHANNEL, msg)
+      // if not playing anything, tell user you're not playing anything
+      console.log('==> No song currently playing.')
+      return client.action(CHANNEL, MSG_NOT_PLAYING)
 
     } else {
       // if data wasn't ever even put into function, tell user it's broken
-      console.log('==> there is no currentlyPlayingData')
-      const msg = 'chatbot/spotify integration is broken lmao'
-      return client.action(CHANNEL, msg)
+      console.log('==> currentlyPlayingData not provided.')
+      return client.action(CHANNEL, MSG_BROKEN)
     }
   }
 
@@ -96,12 +94,12 @@ app.get('/callback', async (req, res) => {
     }
     if (message === '!song') {
       const spotifyCurrentlyPlayingData = await requestSpotify.currentlyPlaying(accessToken)
-      return handleMessaging(spotifyCurrentlyPlayingData, { retries: 3 })
+      return handleMessaging(spotifyCurrentlyPlayingData, { retries: COUNT_RETRIES })
     }
   })
 })
 
-app.listen(port, () => console.log(`Spotify callback app listening on port ${port}`))
+app.listen(port, () => console.log(`Spotify callback API endpoint app listening on port ${port}.`))
 
 const query = {
   client_id: SPOTIFY_CLIENT_ID,
@@ -111,5 +109,5 @@ const query = {
   scope: 'user-read-currently-playing',
 }
 const url = `https://accounts.spotify.com/authorize?${qs.stringify(query)}`
-console.log('==> opening url', url)
+console.log(`==> Opening url: ${url}.`)
 open(url)

--- a/index.js
+++ b/index.js
@@ -11,8 +11,11 @@ const port = 3000
 app.get('/callback', (req, res) => {
   res.send('Authenticated.')
 
-  fetch('https://accounts.spotify.com/api/token', {
+  const spotifyOptionsAuth = {
     method: 'POST',
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded'
+    },
     body: qs.stringify({
       grant_type: 'authorization_code',
       code: req.query.code,
@@ -20,52 +23,67 @@ app.get('/callback', (req, res) => {
       client_id: SPOTIFY_CLIENT_ID,
       client_secret: SPOTIFY_CLIENT_SECRET
     })
-  })
+  }
+
+  const twitchOptions = {
+    options: {
+      debug: true
+    },
+    connection: {
+      cluster: 'aws',
+      reconnect: true
+    },
+    identity: {
+      username: BOT_USER,
+      password: TWITCH_TOKEN
+    },
+    channels: [
+      CHANNEL
+    ]
+  }
+
+  fetch('https://accounts.spotify.com/api/token', spotifyOptionsAuth)
     .then(res => res.json())
     .then(tokens => {
       let accessToken = tokens.access_token
+      let refreshToken = tokens.refresh_token
 
-      const options = {
-        options: {
-          debug: true
-        },
-        connection: {
-          cluster: 'aws',
-          reconnect: true
-        },
-        identity: {
-          username: BOT_USER,
-          password: TWITCH_TOKEN
-        },
-        channels: [
-          CHANNEL
-        ]
-      }
-
-      const client = new twitch.client(options)
-
+      const client = new twitch.client(twitchOptions)
       client.connect()
 
       const handleMessaging = cp => {
         if (cp.error && cp.error.includes('xpire')) {
+          console.log('==> expiration error:', cp.error)
           fetch('https://accounts.spotify.com/api/token', {
             method: 'POST',
             body: qs.stringify({
               grant_type: 'refresh_token',
-              refresh_token: tokens.refresh_token
+              refresh_token: refreshToken
             })
           })
             .then(res => res.json())
-            .then(subTokens => {
-              accessToken = subTokens.access_token
+            .then(updatedTokens => {
+              accessToken = updatedTokens.access_token
+              refreshToken = updatedTokens.refresh_token
               fetch('https://api.spotify.com/v1/me/player/currently-playing', {
                 headers: {
                   Authorization: `Bearer ${accessToken}`
                 }
               })
-                .then(handleMessaging)
+                .catch(err => {
+                  const msg = 'chatbot/spotify integration is broken lmao'
+                  console.log('==> caught error trying to perform refresh request', err)
+                  client.action(CHANNEL, msg)
+                })
+            })
+            .then(handleMessaging)
+            .catch(err => {
+              const msg = 'chatbot/spotify integration is broken lmao'
+              console.log('==> caught error in refresh procedure', err)
+              client.action(CHANNEL, msg)
             })
         } else if (cp.error) {
+          console.log('==> miscellaneous error:', cp.error)
           throw new Error(cp.error)
         }
         if (cp.is_playing && cp.item) {
@@ -73,12 +91,10 @@ app.get('/callback', (req, res) => {
           const title = cp.item.name || 'n/a'
           const album = (cp.item.album && cp.item.album.name) || 'n/a'
           const msg = `${artists} - ${title} [${album}]`
-          console.log(`==> response to ${user}: ${msg}`)
           client.action(CHANNEL, msg)
         } else {
           const msg = 'spotify\'s not playing anything rn'
-          console.log('cp', cp)
-          console.log(`==> response to ${user}: ${msg}`)
+          console.log('==> spotify not playing anything; cp', cp)
           client.action(CHANNEL, msg)
         }
       }
@@ -97,17 +113,22 @@ app.get('/callback', (req, res) => {
             .then(handleMessaging)
             .catch(err => {
               const msg = 'chatbot/spotify integration is broken lmao'
-              console.log(`==> response to ${user}: ${msg}`)
+              console.log('==> caught error in chat action', err)
               client.action(CHANNEL, msg)
             })
           
         }
       })
     })
+    .catch(err => {
+      const msg = 'chatbot/spotify integration is broken lmao'
+      console.log('==> caught error trying to perform initial auth', err)
+      client.action(CHANNEL, msg)
+    })
 
 })
 
-app.listen(port, () => console.log(`Example app listening on port ${port}!`))
+app.listen(port, () => console.log(`Spotify callback app listening on port ${port}`))
 
 const query = {
   client_id: SPOTIFY_CLIENT_ID,

--- a/index.js
+++ b/index.js
@@ -9,8 +9,6 @@ const { BOT_USER, CHANNEL, GAME_ID, TWITCH_TOKEN, SPOTIFY_CLIENT_ID } = require(
 const csrfGenerator = new csrf()
 const CSRF_SECRET = csrfGenerator.secretSync()
 const CSRF_TOKEN = csrfGenerator.create(CSRF_SECRET)
-console.log(CSRF_SECRET)
-console.log(CSRF_TOKEN)
 const MSG_BROKEN = 'chatbot/spotify integration is broken lmao'
 const MSG_NOT_PLAYING = 'i\'m not playing anything on spotify rn'
 const COUNT_RETRIES = 3

--- a/index.js
+++ b/index.js
@@ -1,44 +1,71 @@
-const twitch = require('twitch-js')
 const fetch = require('node-fetch')
-const { BOT_USER, CHANNEL, TWITCH_TOKEN, SPOTIFY_TOKEN, GAME_ID } = require('./vars')
+const express = require('express')
+const twitch = require('twitch-js')
+const qs = require('qs')
+const open = require('open')
+const { BOT_USER, CHANNEL, GAME_ID, TWITCH_TOKEN, SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET } = require('./vars');
 
-const options = {
-  options: {
-    debug: true
-  },
-  connection: {
-    cluster: 'aws',
-    reconnect: true
-  },
-  identity: {
-    username: BOT_USER,
-    password: TWITCH_TOKEN
-  },
-  channels: [
-    CHANNEL
-  ]
-}
+const app = express()
+const port = 3000
 
-const client = new twitch.client(options)
+app.get('/callback', (req, res) => {
+  res.send('Authenticated.')
 
-client.connect()
-
-// open browser with spotify auth thing
-// https://accounts.spotify.com/authorize?client_id=5cdf82fa6fef411e9b2a71d95c08ec2d&response_type=code&redirect_uri=https%3A%2F%2Fcgbuen.io%2Fcallback&scope=user-read-currently-playing
-
-client.on('chat', (channel, user, message, self) => {
-  if (message === '!fc') {
-    client.action(CHANNEL, GAME_ID)
-  }
-  if (message === '!song') {
-    fetch('https://api.spotify.com/v1/me/player/currently-playing', {
-      headers: {
-        Authorization: `Bearer ${SPOTIFY_TOKEN}`
-      }
+  fetch('https://accounts.spotify.com/api/token', {
+    method: 'POST',
+    body: qs.stringify({
+      grant_type: 'authorization_code',
+      code: req.query.code,
+      redirect_uri: 'http://localhost:3000/callback',
+      client_id: SPOTIFY_CLIENT_ID,
+      client_secret: SPOTIFY_CLIENT_SECRET
     })
-      .then(res => res.json())
-      .then(cp => {
-        if (cp.error) {
+  })
+    .then(res => res.json())
+    .then(tokens => {
+      let accessToken = tokens.access_token
+
+      const options = {
+        options: {
+          debug: true
+        },
+        connection: {
+          cluster: 'aws',
+          reconnect: true
+        },
+        identity: {
+          username: BOT_USER,
+          password: TWITCH_TOKEN
+        },
+        channels: [
+          CHANNEL
+        ]
+      }
+
+      const client = new twitch.client(options)
+
+      client.connect()
+
+      const handleMessaging = cp => {
+        if (cp.error && cp.error.includes('xpire')) {
+          fetch('https://accounts.spotify.com/api/token', {
+            method: 'POST',
+            body: qs.stringify({
+              grant_type: 'refresh_token',
+              refresh_token: tokens.refresh_token
+            })
+          })
+            .then(res => res.json())
+            .then(subTokens => {
+              accessToken = subTokens.access_token
+              fetch('https://api.spotify.com/v1/me/player/currently-playing', {
+                headers: {
+                  Authorization: `Bearer ${accessToken}`
+                }
+              })
+                .then(handleMessaging)
+            })
+        } else if (cp.error) {
           throw new Error(cp.error)
         }
         if (cp.is_playing && cp.item) {
@@ -54,12 +81,38 @@ client.on('chat', (channel, user, message, self) => {
           console.log(`==> response to ${user}: ${msg}`)
           client.action(CHANNEL, msg)
         }
+      }
+
+      client.on('chat', (channel, user, message, self) => {
+        if (message === '!fc') {
+          client.action(CHANNEL, GAME_ID)
+        }
+        if (message === '!song') {
+          fetch('https://api.spotify.com/v1/me/player/currently-playing', {
+            headers: {
+              Authorization: `Bearer ${accessToken}`
+            }
+          })
+            .then(res => res.json())
+            .then(handleMessaging)
+            .catch(err => {
+              const msg = 'chatbot/spotify integration is broken lmao'
+              console.log(`==> response to ${user}: ${msg}`)
+              client.action(CHANNEL, msg)
+            })
+          
+        }
       })
-      .catch(err => {
-        const msg = 'chatbot/spotify integration is broken lmao'
-        console.log(`==> response to ${user}: ${msg}`)
-        client.action(CHANNEL, msg)
-      })
-    
-  }
+    })
+
 })
+
+app.listen(port, () => console.log(`Example app listening on port ${port}!`))
+
+const query = {
+  client_id: SPOTIFY_CLIENT_ID,
+  response_type: 'code',
+  redirect_uri: 'http://localhost:3000/callback',
+  scope: 'user-read-currently-playing'
+}
+open(`https://accounts.spotify.com/authorize?${qs.stringify(query)}`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,20 @@
         "@types/node": "*"
       }
     },
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "requires": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
@@ -61,10 +75,83 @@
         "regenerator-runtime": "^0.11.0"
       }
     },
+    "body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "requires": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      }
+    },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+    },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
     "core-js": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
       "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "encoding": {
       "version": "0.1.12",
@@ -72,6 +159,89 @@
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
         "iconv-lite": "~0.4.13"
+      }
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "requires": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
       }
     },
     "iconv-lite": {
@@ -82,35 +252,207 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ipaddr.js": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
     },
     "lodash": {
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
+    "mime-db": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+    },
+    "mime-types": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "requires": {
+        "mime-db": "1.40.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+    },
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "open": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.3.0.tgz",
+      "integrity": "sha512-6AHdrJxPvAXIowO/aIaeHZ8CeMdDf7qCyRNq8NwJpinmCdXhz+NZR7ie1Too94lpciCDsG+qHGO9Mt0svA4OqA==",
+      "requires": {
+        "is-wsl": "^1.1.0"
+      }
     },
     "options": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
       "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
     },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "proxy-addr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+      "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.0"
+      }
+    },
+    "qs": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
+    },
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "twitch-js": {
       "version": "1.2.17",
@@ -147,15 +489,39 @@
         }
       }
     },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
     "ultron": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
     },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
     "validator": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
       "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA=="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "whatwg-fetch": {
       "version": "2.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,6 +125,16 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
       "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
     },
+    "csrf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.1.0.tgz",
+      "integrity": "sha512-uTqEnCvWRk042asU6JtapDTcJeeailFy4ydOQS28bj1hcLnYRiqi8SsD2jS412AY1I/4qdOwWZun774iqywf9w==",
+      "requires": {
+        "rndm": "1.2.0",
+        "tsscmp": "1.0.6",
+        "uid-safe": "2.1.5"
+      }
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -370,6 +380,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
+    "random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
+    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -390,6 +405,11 @@
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+    },
+    "rndm": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
+      "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w="
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -454,6 +474,11 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
+    "tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
+    },
     "twitch-js": {
       "version": "1.2.17",
       "resolved": "https://registry.npmjs.org/twitch-js/-/twitch-js-1.2.17.tgz",
@@ -496,6 +521,14 @@
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
+      }
+    },
+    "uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "requires": {
+        "random-bytes": "~1.0.0"
       }
     },
     "ultron": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "express": "^4.17.1",
     "node-fetch": "^2.6.0",
+    "open": "^6.3.0",
+    "qs": "^6.7.0",
     "twitch-js": "^1.2.17"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "csrf": "^3.1.0",
     "express": "^4.17.1",
     "node-fetch": "^2.6.0",
     "open": "^6.3.0",

--- a/request-spotify.js
+++ b/request-spotify.js
@@ -49,7 +49,14 @@ const currentlyPlaying = async (accessToken) => {
     }
   }
   const spotifyResponseCurrentlyPlaying = await fetch('https://api.spotify.com/v1/me/player/currently-playing', spotifyOptionsCurrentlyPlaying)
-  const data = await spotifyResponseCurrentlyPlaying.json()
+  let data
+  if (spotifyResponseCurrentlyPlaying.statusText === 'OK') {
+    data = await spotifyResponseCurrentlyPlaying.json()
+  } else {
+    // non-OK response seems to imply no active session, so fake a "not
+    // playing" response
+    data = { is_playing: false }
+  }
   return data
 }
 

--- a/request-spotify.js
+++ b/request-spotify.js
@@ -1,0 +1,54 @@
+const fetch = require('node-fetch')
+const qs = require('qs')
+const { SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET } = require('./vars')
+
+const requestSpotifyAuth = async (authCode) => {
+  const spotifyOptionsAuth = {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded'
+    },
+    body: qs.stringify({
+      grant_type: 'authorization_code',
+      code: authCode,
+      redirect_uri: 'http://localhost:3000/callback',
+      client_id: SPOTIFY_CLIENT_ID,
+      client_secret: SPOTIFY_CLIENT_SECRET
+    })
+  }
+  const spotifyResponseAuth = await fetch('https://accounts.spotify.com/api/token', spotifyOptionsAuth)
+  return await spotifyResponseAuth.json()
+}
+
+const requestSpotifyRefresh = async (refreshToken) => {
+  const spotifyOptionsRefresh = {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded'
+    },
+    body: qs.stringify({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      client_id: SPOTIFY_CLIENT_ID,
+      client_secret: SPOTIFY_CLIENT_SECRET
+    })
+  }
+  const spotifyResponseRefresh = await fetch('https://accounts.spotify.com/api/token', spotifyOptionsRefresh)
+  return await spotifyResponseRefresh.json()
+}
+
+const requestSpotifyCurrentlyPlaying = async (accessToken) => {
+  const spotifyOptionsCurrentlyPlaying = {
+    headers: {
+      Authorization: `Bearer ${accessToken}`
+    }
+  }
+  const spotifyResponseCurrentlyPlaying = await fetch('https://api.spotify.com/v1/me/player/currently-playing', spotifyOptionsCurrentlyPlaying)
+  return await spotifyResponseCurrentlyPlaying.json()
+}
+
+module.exports = {
+  requestSpotifyAuth,
+  requestSpotifyRefresh,
+  requestSpotifyCurrentlyPlaying
+}

--- a/request-spotify.js
+++ b/request-spotify.js
@@ -17,8 +17,16 @@ const auth = async (authCode) => {
       client_secret: SPOTIFY_CLIENT_SECRET
     })
   }
-  const spotifyResponseAuth = await fetch('https://accounts.spotify.com/api/token', spotifyOptionsAuth)
-  const data = await spotifyResponseAuth.json()
+  let data
+  try {
+    const spotifyResponseAuth = await fetch('https://accounts.spotify.com/api/token', spotifyOptionsAuth)
+    data = await spotifyResponseAuth.json()
+  } catch (e) {
+    console.log('==> Request fetch error auth', e)
+    data = {
+      error: 'fetch error: auth'
+    }
+  }
   return data
 }
 
@@ -36,8 +44,16 @@ const refresh = async (refreshToken) => {
       client_secret: SPOTIFY_CLIENT_SECRET
     })
   }
-  const spotifyResponseRefresh = await fetch('https://accounts.spotify.com/api/token', spotifyOptionsRefresh)
-  const data = await spotifyResponseRefresh.json()
+  let data
+  try {
+    const spotifyResponseRefresh = await fetch('https://accounts.spotify.com/api/token', spotifyOptionsRefresh)
+    data = await spotifyResponseRefresh.json()
+  } catch(e) {
+    console.log('==> Request fetch error refresh', e)
+    data = {
+      error: 'fetch error: refresh'
+    }
+  }
   return data
 }
 
@@ -48,14 +64,21 @@ const currentlyPlaying = async (accessToken) => {
       Authorization: `Bearer ${accessToken}`
     }
   }
-  const spotifyResponseCurrentlyPlaying = await fetch('https://api.spotify.com/v1/me/player/currently-playing', spotifyOptionsCurrentlyPlaying)
   let data
-  if (spotifyResponseCurrentlyPlaying.statusText === 'OK') {
-    data = await spotifyResponseCurrentlyPlaying.json()
-  } else {
-    // non-OK response seems to imply no active session, so fake a "not
-    // playing" response
-    data = { is_playing: false }
+  try {
+    const spotifyResponseCurrentlyPlaying = await fetch('https://api.spotify.com/v1/me/player/currently-playing', spotifyOptionsCurrentlyPlaying)
+    if (spotifyResponseCurrentlyPlaying.statusText === 'OK') {
+      data = await spotifyResponseCurrentlyPlaying.json()
+    } else {
+      // non-OK response seems to imply no active session, so fake a "not
+      // playing" response
+      data = { is_playing: false, noSession: true }
+    }
+  } catch (e) {
+    console.log('==> Request fetch error currently playing', e)
+    data = {
+      error: 'fetch error: currently playing'
+    }
   }
   return data
 }

--- a/request-spotify.js
+++ b/request-spotify.js
@@ -2,7 +2,8 @@ const fetch = require('node-fetch')
 const qs = require('qs')
 const { SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET } = require('./vars')
 
-const requestSpotifyAuth = async (authCode) => {
+const auth = async (authCode) => {
+  // initial authorization
   const spotifyOptionsAuth = {
     method: 'POST',
     headers: {
@@ -17,10 +18,12 @@ const requestSpotifyAuth = async (authCode) => {
     })
   }
   const spotifyResponseAuth = await fetch('https://accounts.spotify.com/api/token', spotifyOptionsAuth)
-  return await spotifyResponseAuth.json()
+  const data = await spotifyResponseAuth.json()
+  return data
 }
 
-const requestSpotifyRefresh = async (refreshToken) => {
+const refresh = async (refreshToken) => {
+  // refresh token for new access tokens
   const spotifyOptionsRefresh = {
     method: 'POST',
     headers: {
@@ -34,21 +37,24 @@ const requestSpotifyRefresh = async (refreshToken) => {
     })
   }
   const spotifyResponseRefresh = await fetch('https://accounts.spotify.com/api/token', spotifyOptionsRefresh)
-  return await spotifyResponseRefresh.json()
+  const data = await spotifyResponseRefresh.json()
+  return data
 }
 
-const requestSpotifyCurrentlyPlaying = async (accessToken) => {
+const currentlyPlaying = async (accessToken) => {
+  // actual api call for usable data
   const spotifyOptionsCurrentlyPlaying = {
     headers: {
       Authorization: `Bearer ${accessToken}`
     }
   }
   const spotifyResponseCurrentlyPlaying = await fetch('https://api.spotify.com/v1/me/player/currently-playing', spotifyOptionsCurrentlyPlaying)
-  return await spotifyResponseCurrentlyPlaying.json()
+  const data = await spotifyResponseCurrentlyPlaying.json()
+  return data
 }
 
 module.exports = {
-  requestSpotifyAuth,
-  requestSpotifyRefresh,
-  requestSpotifyCurrentlyPlaying
+  auth,
+  refresh,
+  currentlyPlaying
 }


### PR DESCRIPTION
- Update the README with directions on how to create your own Spotify app.
- After creating one and starting the server, the following happens (italicized already existed on master, normal/un-italicized is newly-added in this PR):
  1. Browser opens to a page to allow your own app permission into your Spotify account.
  2. Express server starts which listens for the page that the browser redirects to, after you accept the permissions. (This has procedure has CSRF protection as per the Spotify directions.)
  3. *Kick off Twitch connection (just as before).*
  4. The redirected page you landed on allows for the app to gain an auth code, which you use in a fetch in exchange for an access token (like a temporary, short-lived "password") and refresh token (which you use to get future access tokens).
  5. *Access token allows for requests to be made to the "currently playing" API endpoint, which is kicked off by user chat, based on event handling written into code (just as before).*
  6. When the access token expires (60 min), automatically make the refresh request to get new access tokens and try step no. 5 again.
- Use async/await syntax.