### PR TITLE
Add data for league and salmon run

### DIFF
--- a/endpoints/json-nintendo.js
+++ b/endpoints/json-nintendo.js
@@ -12,10 +12,12 @@ module.exports = async (req, res) => {
   try {
     const playerInfo = {
       player: nintendoStatsResponse.recordsResponse.records.player,
+      league_stats: nintendoStatsResponse.recordsResponse.records.league_stats,
       win_count: nintendoStatsResponse.recordsResponse.records.win_count,
       lose_count: nintendoStatsResponse.recordsResponse.records.lose_count,
       weapon_stats: nintendoStatsResponse.recordsResponse.records.weapon_stats,
-      x_leaderboard: nintendoStatsResponse.xLeaderboardResponse
+      x_leaderboard: nintendoStatsResponse.xLeaderboardResponse,
+      salmon_run: nintendoStatsResponse.salmonRunResponse
     }
 
     const translateMode = mode => {
@@ -65,6 +67,11 @@ module.exports = async (req, res) => {
         rankClamBlitz,
         rankTowerControl
       },
+      league: {
+        ...playerInfo.league_stats,
+        max_league_point_team: playerInfo.player.max_league_point_team,
+        max_league_point_pair: playerInfo.player.max_league_point_pair
+      },
       gear: {
         weapon: {
           ...playerInfo.player.weapon,
@@ -110,6 +117,15 @@ module.exports = async (req, res) => {
           .sort((x, y) => y.win_meter - x.win_meter)
           .map(x => ({ name: x.weapon.name, win_meter: x.win_meter })),
       },
+      salmonRun: {
+        total_golden_eggs: playerInfo.salmon_run.summary.card.golden_ikura_total,
+        total_power_eggs: playerInfo.salmon_run.summary.card.ikura_total,
+        total_points: playerInfo.salmon_run.summary.card.kuma_point_total,
+        total_games: playerInfo.salmon_run.summary.card.job_num,
+        total_rescues: playerInfo.salmon_run.summary.card.help_total,
+        current_points: playerInfo.salmon_run.summary.card.kuma_point,
+        current_level: playerInfo.salmon_run.summary.stats[0].grade_point
+      }
     }
 
 
@@ -125,25 +141,45 @@ module.exports = async (req, res) => {
         `Tower Control: ${nintendoStats.ranks.rankTowerControl}`
       ].map(unbreak).join(', ')
     }`
+    nintendoStats.output_league = {
+      pair: [
+        `[League Pair]`,
+        `Max Power: ${nintendoStats.league.max_league_point_pair},`,
+        `Gold Medals: ${nintendoStats.league.pair.gold_count},`,
+        `Silver Medals: ${nintendoStats.league.pair.silver_count},`,
+        `Bronze Medals: ${nintendoStats.league.pair.bronze_count}`,
+      ].map(unbreak).join(' '),
+      team: [
+        `[League Team]`,
+        `Max Power: ${nintendoStats.league.max_league_point_team},`,
+        `Gold Medals: ${nintendoStats.league.team.gold_count},`,
+        `Silver Medals: ${nintendoStats.league.team.silver_count},`,
+        `Bronze Medals: ${nintendoStats.league.team.bronze_count}`,
+      ].map(unbreak).join(' ')
+    },
     nintendoStats.output_gear = {
       weapon: [
-        `[Current Weapon] ${playerInfo.player.weapon.name.replace(/\s+/g, '\u00A0')}`,
-        `(W-L: ${nintendoStats.gear.weapon.stats.win_count}-${nintendoStats.gear.weapon.stats.lose_count} /`,
+        `[Current Weapon]`,
+        `${playerInfo.player.weapon.name.replace(/\s+/g, '\u00A0')}`,
+        `(W-L: ${nintendoStats.gear.weapon.stats.win_count}-${nintendoStats.gear.weapon.stats.lose_count},`,
         `Turf Inked: ${nFormatter(nintendoStats.gear.weapon.stats.total_paint_point, 2)})`
       ].map(unbreak).join(' '),
       head: [
-        `[Current Headgear] ${playerInfo.player.head.name} (${'\u2605'.repeat(playerInfo.player.head.rarity + 1)})`,
-        `(Main: ${removeParen(playerInfo.player.head_skills.main.name)} /`,
+        `[Current Headgear]`,
+        `${playerInfo.player.head.name} (${'\u2605'.repeat(playerInfo.player.head.rarity + 1)})`,
+        `(Main: ${removeParen(playerInfo.player.head_skills.main)},`,
         `Subs: ${playerInfo.player.head_skills.subs.filter(isNotQuestionMark).map(removeParen).join(', ')})`
       ].map(unbreak).join(' '),
       clothes: [
-        `[Current Clothes] ${playerInfo.player.clothes.name} (${'\u2605'.repeat(playerInfo.player.clothes.rarity + 1)})`,
-        `(Main: ${removeParen(playerInfo.player.clothes_skills.main.name)} /`,
+        `[Current Clothes]`,
+        `${playerInfo.player.clothes.name} (${'\u2605'.repeat(playerInfo.player.clothes.rarity + 1)})`,
+        `(Main: ${removeParen(playerInfo.player.clothes_skills.main)},`,
         `Subs: ${playerInfo.player.clothes_skills.subs.filter(isNotQuestionMark).map(removeParen).join(', ')})`
       ].map(unbreak).join(' '),
       shoes: [
-        `[Current Shoes] ${playerInfo.player.shoes.name} (${'\u2605'.repeat(playerInfo.player.shoes.rarity + 1)})`,
-        `(Main: ${removeParen(playerInfo.player.shoes_skills.main.name)} /`,
+        `[Current Shoes]`,
+        `${playerInfo.player.shoes.name} (${'\u2605'.repeat(playerInfo.player.shoes.rarity + 1)})`,
+        `(Main: ${removeParen(playerInfo.player.shoes_skills.main)},`,
         `Subs: ${playerInfo.player.shoes_skills.subs.filter(isNotQuestionMark).map(removeParen).join(', ')})`
       ].map(unbreak).join(' '),
     }
@@ -155,6 +191,20 @@ module.exports = async (req, res) => {
       games: `[Games Played] ${nintendoStats.weaponStats.games.slice(0, 5).map((x, i) => unbreak(`${i + 1}. ${x.name} (${x.games_played})`)).join(', ')}`,
       turf: `[Turf Inked] ${nintendoStats.weaponStats.turf.slice(0, 5).map((x, i) => unbreak(`${i + 1}. ${x.name} (${nFormatter(x.total_paint_point, 2)})`)).join(', ')}`,
       recent: `[Most Recently Used] ${nintendoStats.weaponStats.recent.slice(0, 5).map((x, i) => unbreak(`${i + 1}. ${x.name} (${moment(x.last_use_time).format('YYYY-MM-DD hh:mma')})`)).join(', ')}`
+    }
+    nintendoStats.output_salmonRun = {
+      overall: [
+        `[Salmon Run]`,
+        `Current Level: ${nintendoStats.salmonRun.current_level},`,
+        `Current Points: ${nintendoStats.salmonRun.current_points},`,
+        `Lifetime Shifts Played: ${nintendoStats.salmonRun.total_games}`,
+      ].map(unbreak).join(' '),
+      individual: [
+        `[Salmon Run Individual Stats]`,
+        `Lifetime Golden Eggs: ${nFormatter(nintendoStats.salmonRun.total_golden_eggs, 2)},`,
+        `Lifetime Power Eggs: ${nFormatter(nintendoStats.salmonRun.total_power_eggs, 2)},`,
+        `Lifetime Crew Members Rescued: ${nintendoStats.salmonRun.total_rescues}`
+      ].map(unbreak).join(' ')
     }
   } catch (e) {
     console.log('** Error retrieving nintendo stats', e)

--- a/helpers/request-nintendo.js
+++ b/helpers/request-nintendo.js
@@ -10,6 +10,7 @@ const getRecords = async (accessToken) => {
   }
   let recordsResponse
   let xLeaderboardResponse
+  let salmonRunResponse
   const now = moment(new Date())
   const nextMonth = now.clone().add(1, 'months')
   const yearMonthNow = `${now.format('YY')}${now.format('MM')}`
@@ -22,13 +23,16 @@ const getRecords = async (accessToken) => {
     console.log('--> Fetching Splatoon X Leaderboard')
     const rawXLeaderboardResponse = await fetch(`https://app.splatoon2.nintendo.net/api/x_power_ranking/${yearMonthNow}01T00_${yearMonthNext}01T00/summary`, requestOptions)
     xLeaderboardResponse = await rawXLeaderboardResponse.json()
+    const rawSalmonRunResponse = await fetch('https://app.splatoon2.nintendo.net/api/coop_results', requestOptions)
+    salmonRunResponse = await rawSalmonRunResponse.json()
   } catch (e) {
     recordsResponse = {}
     xLeaderboardResponse = {}
   }
   return {
     recordsResponse,
-    xLeaderboardResponse
+    xLeaderboardResponse,
+    salmonRunResponse
   }
 }
 


### PR DESCRIPTION
- Pull league data from player records
- Reach out to new new nintendo API endpoint for salmon run
- Fix breakdown issue where bracketed subtitle was not getting found
  properly for gear
- Fix removeParen() usage for single (unmapped) data (e.g. main)