### PR TITLE
Add and update chat commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-build-command
+command-content.json
 node_modules
 token-store
 twitch-logs

--- a/build-command.example
+++ b/build-command.example
@@ -1,1 +1,0 @@
-Example build

--- a/command-content.json.example
+++ b/command-content.json.example
@@ -1,0 +1,11 @@
+{
+  "BUILD": "your build",
+  "BUILD_IS_KEYBOARD": true,
+  "BUILD_NOT_KEYBOARD_MSG": "message for when build is not a keyboard",
+  "CHARITY": "charity message",
+  "SOCIALS_ALL": "message for all social media account links",
+  "SOCIALS_IG": "instagram link",
+  "SOCIALS_TWITTER": "twitter link",
+  "HYPE_GAME": "game excitement message",
+  "HYPE_SUB": "sub excitement message"
+}

--- a/commands/build.js
+++ b/commands/build.js
@@ -1,5 +1,18 @@
 const fs = require('fs')
 
-module.exports = function build() {
-  return fs.readFileSync(`./build-command`)
+module.exports = function build(message) {
+  let msg
+  try {
+    const { BUILD, BUILD_IS_KEYBOARD, BUILD_NOT_KEYBOARD_MSG } = JSON.parse(fs.readFileSync('./command-content.json', 'utf8').trim())
+    if (BUILD_IS_KEYBOARD) {
+      msg = BUILD
+    } else {
+      msg = BUILD_NOT_KEYBOARD_MSG
+    }
+  } catch (e) {
+    console.log('==> Could not parse command-content', e)
+    msg = 'n/a'
+
+  }
+  return msg
 }

--- a/commands/charity.js
+++ b/commands/charity.js
@@ -1,4 +1,13 @@
+const fs = require('fs')
+
 module.exports = function charity() {
-  const msg = 'All proceeds go to the San Francisco-Marin Food Bank. You can donate directly here: https://us-p2p.netdonor.net/1803/general/61375/cgbuen'
+  let msg
+  try {
+    const { CHARITY } = JSON.parse(fs.readFileSync('./command-content.json', 'utf8').trim())
+    msg = CHARITY
+  } catch (e) {
+    console.log('==> Could not parse command-content', e)
+    msg = 'n/a'
+  }
   return msg
 }

--- a/commands/hype.js
+++ b/commands/hype.js
@@ -1,4 +1,17 @@
-module.exports = function hype() {
-  const msg = 'yeeeeeaaaaaa boiiiiiii let\'s crack this rank meter'
+const fs = require('fs')
+
+module.exports = function hype(message) {
+  let msg
+  try {
+    const { HYPE_GAME, HYPE_SUB } = JSON.parse(fs.readFileSync('./command-content.json', 'utf8').trim())
+    if (message === '!subhype') {
+      msg = HYPE_SUB
+    } else {
+      msg = HYPE_GAME
+    }
+  } catch (e) {
+    console.log('==> Could not parse command-content')
+    msg = 'n/a'
+  }
   return msg
 }

--- a/commands/socials.js
+++ b/commands/socials.js
@@ -1,0 +1,19 @@
+const fs = require('fs')
+
+module.exports = function socials(message) {
+  let msg
+  try {
+    const { SOCIALS_ALL, SOCIALS_IG, SOCIALS_TWITTER } = JSON.parse(fs.readFileSync('./command-content.json', 'utf8').trim())
+    if (message === '!instagram') {
+      msg = SOCIALS_IG
+    } else if (message === '!twitter') {
+      msg = SOCIALS_TWITTER
+    } else {
+      msg = SOCIALS_ALL
+    }
+  } catch (e) {
+    console.log('==> Could not parse command-content')
+    msg = 'n/a'
+  }
+  return msg
+}

--- a/commands/stream-status.js
+++ b/commands/stream-status.js
@@ -1,0 +1,60 @@
+const fs = require('fs')
+const requestTwitch = require('../helpers/request-twitch')
+const { CHANNEL, TOKEN_STORE } = require('../vars')
+
+module.exports = async function streamStatus(username, message) {
+  let msg
+  let canSetChannelInfo
+  let gameId
+  const userInput = message.match(/^\!(game|category|title)\s+(.*?)\s*$/)[2]
+  try {
+    const getModsResponse = await requestTwitch.getMods(fs.readFileSync(`./${TOKEN_STORE}/twitch-access`, 'utf8').trim())
+    const mods = getModsResponse.data.map(x => x.userName)
+    mods.push(CHANNEL)
+    canSetChannelInfo = mods.includes(username)
+  } catch (e) {
+    console.log('==> Could not get mods list', e)
+    return 'n/a'
+  }
+  if (!canSetChannelInfo) {
+    return 'ain\'t a mod'
+  }
+  if (message.startsWith('!game') || message.startsWith('!category')) {
+    try {
+      const getGameResponse = await requestTwitch.getGame(userInput, fs.readFileSync(`./${TOKEN_STORE}/twitch-access`, 'utf8').trim())
+      try {
+        gameId = getGameResponse.data[0].id
+      } catch (e) {
+        console.log('==> No game exists on twitch', e)
+        return 'no game bro'
+      }
+    } catch (e) {
+      console.log('==> Could not get game', e)
+      return 'n/a'
+    }
+    try {
+      const setGameResponse = await requestTwitch.setGame(gameId, fs.readFileSync(`./${TOKEN_STORE}/twitch-access`, 'utf8').trim())
+      if (setGameResponse.status === 204) {
+        msg = 'coo'
+      } else {
+        msg = 'twitch buggin rn or somethin'
+      }
+    } catch (e) {
+      console.log('==> Could not set game', e)
+      return 'n/a'
+    }
+  } else {
+    try {
+      const setTitleResponse = await requestTwitch.setTitle(userInput, fs.readFileSync(`./${TOKEN_STORE}/twitch-access`, 'utf8').trim())
+      if (setTitleResponse.status === 204) {
+        msg = 'yep'
+      } else {
+        msg = 'twitch buggin rn or somethin'
+      }
+    } catch (e) {
+      console.log('==> Could not set title', e)
+      return 'n/a'
+    }
+  }
+  return msg
+}

--- a/commands/uptime.js
+++ b/commands/uptime.js
@@ -6,7 +6,6 @@ const { TOKEN_STORE } = require('../vars')
 module.exports = async function up() {
   let uptime
   try {
-    const accessToken = fs.readFileSync(`./${TOKEN_STORE}/spotify-access`)
     const twitchStatsResponses = await requestTwitch.getAllStats(fs.readFileSync(`./${TOKEN_STORE}/twitch-access`, 'utf8').trim())
     const startTime = moment(twitchStatsResponses.streamsResponse.data[0].startedAt)
     const currTime = moment()

--- a/endpoints/chat.js
+++ b/endpoints/chat.js
@@ -49,10 +49,16 @@ module.exports = ({ startTime }) => {
             if (command === 'PRIVMSG') {
               fs.appendFileSync(dateFilename, `[${moment().format()}] <${username}> ${message}\n`)
               let msg
-              if (['!build', '!specs'].includes(message)) {
-                msg = require('../commands/build')()
+              if (['!build', '!specs', '!keyboard'].includes(message)) {
+                msg = require('../commands/build')(message)
               }
-              if (/^\!(chri(s|d)?_?s?u(c|k|x)|rekt)/.test(message)) {
+              if (/^\!(game|category|title)\s+(.*?)\s*$/.test(message)) {
+                msg = await require('../commands/stream-status')(username, message)
+              }
+              if (['!socials', '!instagram', '!twitter'].includes(message)) {
+                msg = require('../commands/socials')(message)
+              }
+              if (/^\!((c|k)h?ri(s|d|z)?_?s?u(c|k|x)|rekt)/.test(message)) {
                 msg = require('../commands/chrissucks')({ username })
               }
               if (message === '!rank') {
@@ -79,8 +85,8 @@ module.exports = ({ startTime }) => {
               if (['!charity', '!support', '!donate', '!bits', '!sub', '!subs', '!subscribe'].includes(message)) {
                 msg = require('../commands/charity')()
               }
-              if (message === '!hype') {
-                msg = require('../commands/hype')()
+              if (['!hype', '!subhype'].includes(message)) {
+                msg = require('../commands/hype')(message)
               }
               if (message === '!lurk') {
                 msg = require('../commands/lurk')()
@@ -112,8 +118,8 @@ module.exports = ({ startTime }) => {
           const twitchTokenDataUpdated = await requestTwitch.refresh(fs.readFileSync(`./${TOKEN_STORE}/twitch-refresh`, 'utf8'))
           return connectToChat(twitchTokenDataUpdated.access_token, { retries: retries - 1 }) // try again after tokens updated
         } else {
-          const msg = 'Error unrelated to authentication failure. Try re-initializing tokens by hitting /inittoken-twitch.'
-          const htmlMsg = `Error unrelated to authentication failure. Try re-initializing tokens by hitting the <a href="/inittoken-twitch">Twitch token initialization endpoint</a>.`
+          const msg = 'Error unrelated to authentication failure. Try re-initializing tokens by hitting /init-twitch.'
+          const htmlMsg = `Error unrelated to authentication failure. Try re-initializing tokens by hitting the <a href="/init-twitch">Twitch token initialization endpoint</a>.`
           console.log(`** ${msg}`, e)
           return res.send(`
             <html>

--- a/endpoints/init-twitch.js
+++ b/endpoints/init-twitch.js
@@ -24,6 +24,8 @@ const init = async (req, res) => {
       'channel_subscriptions',
       'chat:edit',
       'chat:read',
+      'moderation:read',
+      'user:edit:broadcast',
       'whispers:edit',
       'whispers:read',
     ].join('__PLUS__')

--- a/endpoints/json-internal-stats.js
+++ b/endpoints/json-internal-stats.js
@@ -6,7 +6,14 @@ const unbreak = require('../helpers/unbreak')
 module.exports = (req, res) => {
   res.header('Access-Control-Allow-Origin', '*')
 
-  const build = fs.readFileSync(`./build-command`)
+  let build
+  try {
+    const { BUILD } = JSON.parse(fs.readFileSync(`./command-content.json`))
+    build = BUILD
+  } catch (e) {
+    console.log('==> Could not parse command-content')
+    build = 'n/a'
+  }
   const charity = "Donations to this channel will be sent off to the San Francisco-Marin Food Bank. You can also donate directly to them through the link at the bottom of the channel notes."
 
   let dict

--- a/endpoints/pubsub.js
+++ b/endpoints/pubsub.js
@@ -47,8 +47,8 @@ module.exports = async (req, res) => {
               ws.close()
               return connectToPubSub(twitchTokenDataUpdated.access_token, { retries: retries - 1 }) // try again after tokens updated
             } else {
-              const msg = 'Error unrelated to authentication failure. Try re-initializing tokens by hitting /inittoken-twitch.'
-              const htmlMsg = `Error unrelated to authentication failure. Try re-initializing tokens by hitting the <a href="/inittoken-twitch">Twitch token initialization endpoint</a>.`
+              const msg = 'Error unrelated to authentication failure. Try re-initializing tokens by hitting /init-twitch.'
+              const htmlMsg = `Error unrelated to authentication failure. Try re-initializing tokens by hitting the <a href="/init-twitch">Twitch token initialization endpoint</a>.`
               console.log(`** ${msg}`)
               ws.close()
               return res.send(`

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "chatbot",
+  "name": "twitchbot",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",


### PR DESCRIPTION
- And and update actual usable chat commands (more regex compatibility
  for !chrissucks, !keyboard to mirror !build, !socials and individual
  social media commands,  !subhype command distinct from !hype, !game
  and !title [for mods only, hopefully])
- Add corresponding twitch methods for: getMods, getGame, setGame, and
  setTitle (the latter two of which need node-fetch instead of twitch-js
  to make requests due to lack of PATCH request support)
- Update build-command to command-content json file with more
  configurable but not tokenized content, and update corresponding
  references, gitignore unversioning, and example file
- Add proper scopes for getting mod list and editing channel info
- Update build command to account for when something is or isn't a
  keyboard

Additionally:

- Remove unnecessary access token assignment in !uptime
- Fix re-tokenization links
- Fix package.json name
- Remove unnecessary Authorization headers for helix requests (only
  client-id was previously needed in July, not both)
- Update try-catch logging, including addition of actual stack logging,
  plus correcting improper naming